### PR TITLE
Add course and unit detail pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 **URL**: https://lovable.dev/projects/e2a4592e-1f23-4523-84f9-4a25af8f78be
 
+### Novos recursos
+
+- Hooks `useCurso` e `useUnidade` para obter dados individuais do Supabase.
+- Páginas `/curso/:id` e `/unidade/:id` exibindo detalhes e conteúdos.
+- Componentes `UnitCard` e `ContentAccordion` para organização de unidades e conteúdos.
+
 ## How can I edit this code?
 
 There are several ways of editing your application.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,8 @@ import { Header } from "@/components/Header";
 import Index from "./pages/Index";
 import Auth from "./pages/Auth";
 import Cursos from "./pages/Cursos";
+import CursoDetalhe from "./pages/CursoDetalhe";
+import Unidade from "./pages/Unidade";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -25,6 +27,15 @@ const App = () => (
             <Route path="/" element={<Index />} />
             <Route path="/auth" element={<Auth />} />
             <Route path="/cursos" element={<Cursos />} />
+            <Route path="/curso/:id" element={<CursoDetalhe />} />
+            <Route
+              path="/unidade/:id"
+              element={
+                <ProtectedRoute>
+                  <Unidade />
+                </ProtectedRoute>
+              }
+            />
             <Route path="/unidades" element={
               <ProtectedRoute>
                 <div className="container mx-auto py-8">

--- a/src/components/ContentAccordion.tsx
+++ b/src/components/ContentAccordion.tsx
@@ -1,0 +1,53 @@
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from "@/components/ui/accordion";
+import { Badge } from "@/components/ui/badge";
+import type { Database } from "@/integrations/supabase/types";
+
+interface ContentItem {
+  ordem: number;
+  conteudos: Database["public"]["Tables"]["conteudos"]["Row"] & {
+    conteudos_tags?: { tags: { nome: string; cor: string } }[];
+  };
+}
+
+interface ContentAccordionProps {
+  conteudos: ContentItem[];
+  unidadeId: string;
+}
+
+export const ContentAccordion = ({ conteudos }: ContentAccordionProps) => {
+  const ordered = [...conteudos].sort((a, b) => a.ordem - b.ordem);
+
+  return (
+    <Accordion type="multiple" className="w-full">
+      {ordered.map((item) => (
+        <AccordionItem key={item.conteudos.id} value={item.conteudos.id}>
+          <AccordionTrigger>
+            <span>{item.conteudos.titulo}</span>
+            {item.conteudos.duracao_minutos && (
+              <Badge variant="secondary" className="ml-2">
+                {item.conteudos.duracao_minutos} min
+              </Badge>
+            )}
+          </AccordionTrigger>
+          <AccordionContent className="space-y-2">
+            {item.conteudos.descricao && (
+              <p className="text-sm text-muted-foreground">
+                {item.conteudos.descricao}
+              </p>
+            )}
+            {item.conteudos.url && (
+              <a
+                href={item.conteudos.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-primary underline"
+              >
+                Abrir conteúdo
+              </a>
+            )}
+          </AccordionContent>
+        </AccordionItem>
+      ))}
+    </Accordion>
+  );
+};

--- a/src/components/UnitCard.tsx
+++ b/src/components/UnitCard.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Link } from "react-router-dom";
+import type { UnidadeCurricular } from "@/hooks/useUnidades";
+
+interface UnitCardProps {
+  unidade: UnidadeCurricular;
+}
+
+export const UnitCard = ({ unidade }: UnitCardProps) => {
+  return (
+    <Card className="group hover:shadow-lg transition-all duration-300">
+      <CardHeader>
+        <CardTitle className="group-hover:text-primary transition-colors">
+          {unidade.nome}
+        </CardTitle>
+        {unidade.descricao && (
+          <CardDescription className="line-clamp-2">
+            {unidade.descricao}
+          </CardDescription>
+        )}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="flex items-center gap-4 text-sm text-muted-foreground">
+          <span>{unidade.semestre}º semestre</span>
+          <Badge variant="secondary">{unidade.ects} ECTS</Badge>
+        </div>
+        <Button asChild className="w-full">
+          <Link to={`/unidade/${unidade.id}`}>Acessar Unidade</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/pages/CursoDetalhe.tsx
+++ b/src/pages/CursoDetalhe.tsx
@@ -1,0 +1,65 @@
+import { useParams, Link } from "react-router-dom";
+import { useCurso } from "@/hooks/useCursos";
+import { UnitCard } from "@/components/UnitCard";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+
+export default function CursoDetalhe() {
+  const { id } = useParams<{ id: string }>();
+  const { data: curso, isLoading, error } = useCurso(id || "");
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Erro ao carregar curso: {error.message}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <Link
+        to="/cursos"
+        className="flex items-center text-sm text-muted-foreground hover:text-primary"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" /> Voltar
+      </Link>
+
+      {isLoading || !curso ? (
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/2" />
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold">{curso.nome}</h1>
+            {curso.universidades?.nome && (
+              <p className="text-muted-foreground">
+                {curso.universidades.nome}
+              </p>
+            )}
+            {curso.descricao && <p>{curso.descricao}</p>}
+          </div>
+
+          {curso.cursos_unidades && curso.cursos_unidades.length > 0 && (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {curso.cursos_unidades.map((cu) => (
+                <UnitCard
+                  key={cu.unidades_curriculares.id}
+                  unidade={cu.unidades_curriculares}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Unidade.tsx
+++ b/src/pages/Unidade.tsx
@@ -1,0 +1,56 @@
+import { Link, useParams } from "react-router-dom";
+import { useUnidade } from "@/hooks/useUnidades";
+import { ContentAccordion } from "@/components/ContentAccordion";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ArrowLeft } from "lucide-react";
+
+export default function Unidade() {
+  const { id } = useParams<{ id: string }>();
+  const { data: unidade, isLoading, error } = useUnidade(id || "");
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Erro ao carregar unidade: {error.message}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <Link
+        to="/cursos"
+        className="flex items-center text-sm text-muted-foreground hover:text-primary"
+      >
+        <ArrowLeft className="w-4 h-4 mr-2" /> Voltar
+      </Link>
+
+      {isLoading || !unidade ? (
+        <div className="space-y-4">
+          <Skeleton className="h-8 w-1/2" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : (
+        <>
+          <div className="space-y-2">
+            <h1 className="text-3xl font-bold">{unidade.nome}</h1>
+            {unidade.descricao && (
+              <p className="text-muted-foreground">{unidade.descricao}</p>
+            )}
+          </div>
+          {unidade.unidades_conteudos && (
+            <ContentAccordion
+              conteudos={unidade.unidades_conteudos}
+              unidadeId={unidade.id}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `UnitCard` component
- add `ContentAccordion` component
- implement `/curso/:id` and `/unidade/:id` pages using new hooks
- wire new pages in router
- document new features in README

## Testing
- `npm run lint` *(fails: 10 errors, 8 warnings)*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_687cb3fe6d88832282d9b1f188a80111