### PR TITLE
Add license summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## External dependencies and licenses
+
+This project relies on several open source libraries. Key dependencies and their licenses include:
+
+- [React](https://github.com/facebook/react/blob/main/LICENSE) – MIT License
+- [Vite](https://github.com/vitejs/vite/blob/main/LICENSE) – MIT License
+- [Tailwind CSS](https://github.com/tailwindlabs/tailwindcss/blob/master/LICENSE) – MIT License
+- [shadcn-ui](https://github.com/shadcn-ui/ui/blob/main/LICENSE.md) – MIT License
+- [Supabase JS](https://github.com/supabase/supabase-js/blob/master/LICENSE) – MIT License
+- [Radix UI](https://github.com/radix-ui/primitives/blob/main/LICENSE) – MIT License
+- [React Router](https://github.com/remix-run/react-router/blob/main/LICENSE.md) – MIT License
+- [TanStack Query](https://github.com/TanStack/query/blob/main/LICENSE) – MIT License
+- [Zod](https://github.com/colinhacks/zod/blob/master/LICENSE) – MIT License
+- [Lucide](https://github.com/lucide-icons/lucide/blob/main/LICENSE) – ISC License
+
+All other dependencies are distributed under their respective open-source licenses.
+
 ## Database setup
 
 1. Install the [Supabase CLI](https://supabase.com/docs/guides/cli):


### PR DESCRIPTION
## Summary
- document external dependencies and licenses in README

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687cbfd9ec908322bd8bfa7ae2c11438