### PR TITLE
Implement new hooks and pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
-# Copy this file to .env and fill in your Supabase credentials
+# Copy this file to .env.local and fill in your Supabase credentials
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-public-anon-key

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ colaborativa alimentada com conteúdos gratuitos da internet.
 
 ### Novos recursos
 
-- Hooks `useCurso` e `useUnidade` para obter dados individuais do Supabase.
-- Páginas `/curso/:id` e `/unidade/:id` exibindo detalhes e conteúdos.
-- Componentes `UnitCard` e `ContentAccordion` para organização de unidades e conteúdos.
+- Hooks adicionais como `useConteudos`, `useRepositorios` e `useTags`.
+- Páginas de listagem de unidades, comunidade, repositório e perfil do usuário.
+- Testes com Vitest e workflow de CI para lint e testes.
 
 ## Prerequisites
 
@@ -123,11 +123,11 @@ All other dependencies are distributed under their respective open-source licens
 
 ### Environment variables
 
-Copy `.env.example` to `.env` and update the values with your Supabase project credentials:
+Copy `.env.example` to `.env.local` and update the values with your Supabase project credentials:
 
 ```sh
-cp .env.example .env
-# then edit .env
+cp .env.example .env.local
+# then edit .env.local
 ```
 
 `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` are used in `src/integrations/supabase/client.ts` to connect the frontend with your Supabase instance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,7 @@
       "devDependencies": {
         "@eslint/js": "^9.9.0",
         "@tailwindcss/typography": "^0.5.15",
+        "@testing-library/react": "^16.3.0",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -124,6 +125,22 @@
         "lru-cache": "^10.4.3"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
@@ -135,9 +152,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.25.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3066,6 +3083,63 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+      "integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "chalk": "^4.1.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.0.tgz",
+      "integrity": "sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
@@ -3711,6 +3785,17 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -4756,6 +4841,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -4773,6 +4869,14 @@
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -6671,6 +6775,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -7240,6 +7355,55 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@eslint/js": "^9.9.0",
     "@tailwindcss/typography": "^0.5.15",
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,10 @@ import Auth from "./pages/Auth";
 import Cursos from "./pages/Cursos";
 import CursoDetalhe from "./pages/CursoDetalhe";
 import UnidadeDetalhe from "./pages/UnidadeDetalhe";
+import Unidades from "./pages/Unidades";
+import Comunidade from "./pages/Comunidade";
+import Repositorio from "./pages/Repositorio";
+import Perfil from "./pages/Perfil";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -36,38 +40,38 @@ const App = () => (
                 </ProtectedRoute>
               }
             />
-            <Route path="/unidades" element={
-              <ProtectedRoute>
-                <div className="container mx-auto py-8">
-                  <h1 className="text-3xl font-bold">Unidades Curriculares</h1>
-                  <p className="text-muted-foreground mt-2">Em desenvolvimento...</p>
-                </div>
-              </ProtectedRoute>
-            } />
-            <Route path="/comunidade" element={
-              <ProtectedRoute>
-                <div className="container mx-auto py-8">
-                  <h1 className="text-3xl font-bold">Comunidade</h1>
-                  <p className="text-muted-foreground mt-2">Em desenvolvimento...</p>
-                </div>
-              </ProtectedRoute>
-            } />
-            <Route path="/repositorio" element={
-              <ProtectedRoute>
-                <div className="container mx-auto py-8">
-                  <h1 className="text-3xl font-bold">Repositório</h1>
-                  <p className="text-muted-foreground mt-2">Em desenvolvimento...</p>
-                </div>
-              </ProtectedRoute>
-            } />
-            <Route path="/perfil" element={
-              <ProtectedRoute>
-                <div className="container mx-auto py-8">
-                  <h1 className="text-3xl font-bold">Perfil</h1>
-                  <p className="text-muted-foreground mt-2">Em desenvolvimento...</p>
-                </div>
-              </ProtectedRoute>
-            } />
+            <Route
+              path="/unidades"
+              element={
+                <ProtectedRoute>
+                  <Unidades />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/comunidade"
+              element={
+                <ProtectedRoute>
+                  <Comunidade />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/repositorio"
+              element={
+                <ProtectedRoute>
+                  <Repositorio />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/perfil"
+              element={
+                <ProtectedRoute>
+                  <Perfil />
+                </ProtectedRoute>
+              }
+            />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
           </Routes>

--- a/src/__tests__/useCursos.test.tsx
+++ b/src/__tests__/useCursos.test.tsx
@@ -1,0 +1,36 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+vi.mock('../integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(() => ({
+      select: () => ({ order: () => Promise.resolve({ data: [], error: null }) })
+    }))
+  }
+}));
+
+import { useCursos } from '../hooks/useCursos';
+import { supabase } from '../integrations/supabase/client';
+
+const queryClient = new QueryClient();
+
+// Mock supabase
+vi.spyOn(supabase, 'from').mockReturnValue({
+  select: () => ({ order: () => Promise.resolve({ data: [], error: null }) })
+} as any);
+
+describe('useCursos', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches cursos', async () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+
+    const { result } = renderHook(() => useCursos(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,6 @@
+export * from './useCursos';
+export * from './useUnidades';
+export * from './useComentarios';
+export * from './useConteudos';
+export * from './useRepositorios';
+export * from './useTags';

--- a/src/hooks/useConteudos.ts
+++ b/src/hooks/useConteudos.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+export interface ConteudoItem {
+  ordem: number | null;
+  conteudos: Database['public']['Tables']['conteudos']['Row'] & {
+    conteudos_tags?: { tags: { nome: string; cor: string | null } }[];
+  };
+}
+
+export const useConteudos = (unidadeId: string) => {
+  return useQuery({
+    queryKey: ['conteudos', unidadeId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('unidades_conteudos')
+        .select(
+          `ordem, conteudos (*, conteudos_tags ( tags ( nome, cor ) ))`
+        )
+        .eq('unidade_id', unidadeId)
+        .order('ordem');
+
+      if (error) throw error;
+      return data as ConteudoItem[];
+    },
+    enabled: !!unidadeId,
+  });
+};

--- a/src/hooks/useRepositorios.ts
+++ b/src/hooks/useRepositorios.ts
@@ -1,0 +1,77 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface Repositorio {
+  id: string;
+  titulo: string;
+  descricao: string | null;
+  arquivo_url: string;
+  tipo_arquivo: string | null;
+  tamanho_kb: number | null;
+  downloads: number | null;
+  aprovado: boolean | null;
+  created_at: string;
+  updated_at: string;
+  user_id: string | null;
+}
+
+export const useRepositorios = (unidadeId?: string) => {
+  return useQuery({
+    queryKey: ['repositorios', unidadeId],
+    queryFn: async () => {
+      let query = supabase
+        .from('repositorios')
+        .select('*')
+        .order('created_at', { ascending: false });
+
+      if (unidadeId) query = query.eq('unidade_id', unidadeId);
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data as Repositorio[];
+    },
+  });
+};
+
+export const useUploadMaterial = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      file,
+      titulo,
+      descricao,
+      unidadeId,
+    }: {
+      file: File;
+      titulo: string;
+      descricao?: string;
+      unidadeId?: string;
+    }) => {
+      const ext = file.name.split('.').pop();
+      const path = `${Date.now()}-${file.name}`;
+
+      const { error: uploadError } = await supabase.storage
+        .from('repositorio')
+        .upload(path, file);
+      if (uploadError) throw uploadError;
+
+      const { data, error } = await supabase
+        .from('repositorios')
+        .insert({
+          titulo,
+          descricao: descricao || null,
+          arquivo_url: path,
+          tipo_arquivo: ext,
+          unidade_id: unidadeId || null,
+        })
+        .select()
+        .single();
+      if (error) throw error;
+      return data as Repositorio;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['repositorios'] });
+    },
+  });
+};

--- a/src/hooks/useTags.ts
+++ b/src/hooks/useTags.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export interface Tag {
+  id: string;
+  nome: string;
+  cor: string | null;
+  created_at: string;
+}
+
+export const useTags = () => {
+  return useQuery({
+    queryKey: ['tags'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('tags')
+        .select('*')
+        .order('nome');
+      if (error) throw error;
+      return data as Tag[];
+    },
+  });
+};

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://osdfvbjagfyvdhtkndus.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im9zZGZ2YmphZ2Z5dmRodGtuZHVzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI0NzY1MjYsImV4cCI6MjA2ODA1MjUyNn0.DAWRcYchkmMESzRZPFXrf_ac4LjuptSC0oF6nb0mVYE";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/pages/Comunidade.tsx
+++ b/src/pages/Comunidade.tsx
@@ -1,0 +1,50 @@
+import { useAllComentarios } from '@/hooks/useComentarios';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Comunidade() {
+  const { data: comentarios, isLoading, error } = useAllComentarios('recent');
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Erro ao carregar comentários: {error.message}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-4">
+      <h1 className="text-3xl font-bold">Comunidade</h1>
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-1/2 mb-2" />
+                <Skeleton className="h-4 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : comentarios && comentarios.length > 0 ? (
+        <div className="space-y-2">
+          {comentarios.map(c => (
+            <Card key={c.id}>
+              <CardContent className="p-4 space-y-1">
+                <p className="font-medium">{c.perfis?.nome}</p>
+                <p className="text-sm">{c.texto}</p>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground">Nenhum comentário ainda.</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Perfil.tsx
+++ b/src/pages/Perfil.tsx
@@ -1,0 +1,30 @@
+import { useAuth } from '@/hooks/useAuth';
+import { useMeusCursos } from '@/hooks/useCursos';
+import { ProgressBar } from '@/components/ProgressBar';
+
+export default function Perfil() {
+  const { user } = useAuth();
+  const { data: cursos } = useMeusCursos();
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Perfil</h1>
+      {user && (
+        <div className="space-y-1">
+          <p className="font-medium">{user.email}</p>
+        </div>
+      )}
+      {cursos && cursos.length > 0 && (
+        <div className="space-y-4">
+          <h2 className="text-2xl font-bold">Cursos Inscritos</h2>
+          {cursos.map(c => (
+            <div key={c.id} className="space-y-1">
+              <p className="font-medium">{c.cursos.nome}</p>
+              <ProgressBar value={0} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Repositorio.tsx
+++ b/src/pages/Repositorio.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useRepositorios, useUploadMaterial } from '@/hooks/useRepositorios';
+import { UploadForm } from '@/components/UploadForm';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { supabase } from '@/integrations/supabase/client';
+
+export default function Repositorio() {
+  const { data: repos, isLoading, error } = useRepositorios();
+  const upload = useUploadMaterial();
+
+  const handleUpload = (file: File) => {
+    upload.mutate({ file, titulo: file.name });
+  };
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Erro ao carregar materiais: {error.message}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-4">
+      <h1 className="text-3xl font-bold">Repositório</h1>
+      <UploadForm onUpload={handleUpload} uploading={upload.isPending} />
+      {isLoading ? (
+        <div className="space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-4">
+                <Skeleton className="h-4 w-1/2 mb-2" />
+                <Skeleton className="h-4 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : repos && repos.length > 0 ? (
+        <div className="space-y-2">
+          {repos.map(r => (
+            <Card key={r.id}>
+              <CardContent className="p-4 flex items-center justify-between">
+                <span>{r.titulo}</span>
+                <Button asChild variant="link" size="sm">
+                  <a href={supabase.storage.from('repositorio').getPublicUrl(r.arquivo_url).data.publicUrl} target="_blank" rel="noreferrer">Baixar</a>
+                </Button>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : (
+        <p className="text-muted-foreground">Nenhum material disponível.</p>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Unidades.tsx
+++ b/src/pages/Unidades.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useUnidades } from '@/hooks/useUnidades';
+import { useTags } from '@/hooks/useTags';
+import { UnitCard, TagChip } from '@/components';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function Unidades() {
+  const [search, setSearch] = useState('');
+  const { data: tags } = useTags();
+  const [tag, setTag] = useState<string | undefined>();
+
+  const { data: unidades, isLoading, error } = useUnidades({ tag });
+
+  const filtered = unidades?.filter(u =>
+    u.nome.toLowerCase().includes(search.toLowerCase())
+  );
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <Card>
+          <CardContent className="p-6 text-destructive">
+            Erro ao carregar unidades: {error.message}
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8 space-y-6">
+      <div className="flex gap-4 items-center">
+        <Input
+          placeholder="Pesquisar unidade..."
+          value={search}
+          onChange={e => setSearch(e.target.value)}
+        />
+        {tags && (
+          <select
+            className="border rounded p-2"
+            value={tag || ''}
+            onChange={e => setTag(e.target.value || undefined)}
+          >
+            <option value="">Todas as tags</option>
+            {tags.map(t => (
+              <option key={t.id} value={t.nome}>{t.nome}</option>
+            ))}
+          </select>
+        )}
+      </div>
+      {isLoading ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i}>
+              <CardContent className="p-6">
+                <Skeleton className="h-6 w-full mb-2" />
+                <Skeleton className="h-4 w-3/4 mb-4" />
+                <Skeleton className="h-10 w-full" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      ) : filtered && filtered.length > 0 ? (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          {filtered.map(u => (
+            <UnitCard key={u.id} unidade={u} />
+          ))}
+        </div>
+      ) : (
+        <Card className="p-8 text-center">
+          <CardContent>
+            <p className="text-muted-foreground">Nenhuma unidade encontrada.</p>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor Supabase client to use env vars
- add hooks for contents, repository and tags
- create pages for Unidades, Comunidade, Repositorio and Perfil
- integrate new pages in router
- add Vitest test for useCursos
- update README instructions

## Testing
- `npm run lint --if-present` *(fails: Unexpected any, etc.)*
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687ccb65818c83229c564e80418e0956