### PR TITLE
Fix lint in useCursos test

### DIFF
--- a/src/__tests__/useCursos.test.tsx
+++ b/src/__tests__/useCursos.test.tsx
@@ -15,9 +15,15 @@ import { supabase } from '../integrations/supabase/client';
 const queryClient = new QueryClient();
 
 // Mock supabase
+interface SupabaseFromMock {
+  select: () => {
+    order: () => Promise<{ data: unknown[]; error: null }>;
+  };
+}
+
 vi.spyOn(supabase, 'from').mockReturnValue({
   select: () => ({ order: () => Promise.resolve({ data: [], error: null }) })
-} as any);
+} as unknown as SupabaseFromMock);
 
 describe('useCursos', () => {
   afterEach(() => {


### PR DESCRIPTION
## Summary
- fix type for mocked supabase 'from' call in `useCursos.test.tsx`

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_687cd04acd6483229cb7f484d0a80060