### PR TITLE
Migrate components to shadcn/ui

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,12 @@
 import { Link } from "react-router-dom";
 import { Button } from "@/components/ui/button";
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from "@/components/ui/navigation-menu";
 import { useAuth } from "@/hooks/useAuth";
 import { UserMenu } from "./UserMenu";
 import { GraduationCap, Menu } from "lucide-react";
@@ -10,36 +17,26 @@ export function Header() {
   const { user } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
 
+  const links = [
+    { to: "/cursos", label: "Cursos" },
+    { to: "/unidades", label: "Unidades" },
+    { to: "/comunidade", label: "Comunidade" },
+    { to: "/repositorio", label: "Repositório" },
+  ];
+
   const NavLinks = () => (
     <>
-      <Link
-        to="/cursos"
-        className="text-sm font-medium transition-colors hover:text-primary"
-        onClick={() => setIsOpen(false)}
-      >
-        Cursos
-      </Link>
-      <Link
-        to="/unidades"
-        className="text-sm font-medium transition-colors hover:text-primary"
-        onClick={() => setIsOpen(false)}
-      >
-        Unidades
-      </Link>
-      <Link
-        to="/comunidade"
-        className="text-sm font-medium transition-colors hover:text-primary"
-        onClick={() => setIsOpen(false)}
-      >
-        Comunidade
-      </Link>
-      <Link
-        to="/repositorio"
-        className="text-sm font-medium transition-colors hover:text-primary"
-        onClick={() => setIsOpen(false)}
-      >
-        Repositório
-      </Link>
+      {links.map((link) => (
+        <NavigationMenuItem key={link.to}>
+          <NavigationMenuLink
+            asChild
+            className={navigationMenuTriggerStyle()}
+            onClick={() => setIsOpen(false)}
+          >
+            <Link to={link.to}>{link.label}</Link>
+          </NavigationMenuLink>
+        </NavigationMenuItem>
+      ))}
     </>
   );
 
@@ -57,9 +54,11 @@ export function Header() {
           </Link>
 
           {user && (
-            <nav className="hidden md:flex items-center space-x-6">
-              <NavLinks />
-            </nav>
+            <NavigationMenu className="hidden md:flex">
+              <NavigationMenuList className="space-x-6">
+                <NavLinks />
+              </NavigationMenuList>
+            </NavigationMenu>
           )}
         </div>
 
@@ -74,9 +73,11 @@ export function Header() {
                     </Button>
                   </SheetTrigger>
                   <SheetContent side="right" className="w-80">
-                    <div className="flex flex-col space-y-4 mt-6">
-                      <NavLinks />
-                    </div>
+                    <NavigationMenu className="mt-6 w-full">
+                      <NavigationMenuList className="flex-col space-y-4">
+                        <NavLinks />
+                      </NavigationMenuList>
+                    </NavigationMenu>
                   </SheetContent>
                 </Sheet>
               </div>

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "@/hooks/useAuth";
-import { Loader2 } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
 
 interface ProtectedRouteProps {
   children: ReactNode;
@@ -13,7 +13,7 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+        <Spinner className="h-8 w-8 text-primary" />
       </div>
     );
   }

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,8 @@
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { ComponentProps } from "react";
+
+export function Spinner({ className, ...props }: ComponentProps<typeof Loader2>) {
+  return <Loader2 className={cn("animate-spin", className)} {...props} />;
+}
+

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,7 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 
 const NotFound = () => {
   const location = useLocation();
@@ -12,14 +14,18 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100">
-      <div className="text-center">
-        <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
-        </a>
-      </div>
+    <div className="min-h-screen flex items-center justify-center">
+      <Card className="w-80 text-center">
+        <CardHeader>
+          <CardTitle>404</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-muted-foreground">Oops! Page not found</p>
+          <Button asChild className="w-full">
+            <Link to="/">Return to Home</Link>
+          </Button>
+        </CardContent>
+      </Card>
     </div>
   );
 };

--- a/src/pages/Unidades.tsx
+++ b/src/pages/Unidades.tsx
@@ -5,6 +5,13 @@ import { UnitCard, TagChip } from '@/components';
 import { Input } from '@/components/ui/input';
 import { Card, CardContent } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 
 export default function Unidades() {
   const [search, setSearch] = useState('');
@@ -38,16 +45,20 @@ export default function Unidades() {
           onChange={e => setSearch(e.target.value)}
         />
         {tags && (
-          <select
-            className="border rounded p-2"
+          <Select
             value={tag || ''}
-            onChange={e => setTag(e.target.value || undefined)}
+            onValueChange={value => setTag(value || undefined)}
           >
-            <option value="">Todas as tags</option>
-            {tags.map(t => (
-              <option key={t.id} value={t.nome}>{t.nome}</option>
-            ))}
-          </select>
+            <SelectTrigger className="w-48">
+              <SelectValue placeholder="Todas as tags" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Todas as tags</SelectItem>
+              {tags.map(t => (
+                <SelectItem key={t.id} value={t.nome}>{t.nome}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         )}
       </div>
       {isLoading ? (


### PR DESCRIPTION
## Summary
- add Spinner component using Lucide Loader2
- refactor ProtectedRoute to use Spinner
- replace Header navigation with NavigationMenu
- convert NotFound page to Card/Button
- use Select component on Unidades page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687cd48a74c08322a2a112442938028c